### PR TITLE
Added :identifier option to disqus_thread

### DIFF
--- a/disqus.gemspec
+++ b/disqus.gemspec
@@ -1,5 +1,3 @@
-require 'disqus/version'
-
 spec = Gem::Specification.new do |s|
 
   s.name              = "disqus"

--- a/disqus.gemspec
+++ b/disqus.gemspec
@@ -1,3 +1,5 @@
+require 'disqus/version'
+
 spec = Gem::Specification.new do |s|
 
   s.name              = "disqus"

--- a/lib/disqus/widget.rb
+++ b/lib/disqus/widget.rb
@@ -34,6 +34,9 @@ module Disqus
         if opts[:developer]
           s << '<script type="text/javascript">var disqus_developer = 1;</script>'
         end
+        if opts[:identifier]
+          s << '<script type="text/javascript">var disqus_identifier = "' + opts[:identifier].to_s + '";</script>'
+        end
         s << '<div id="disqus_thread"></div>'
         s << '<script type="text/javascript" src="' + THREAD + '"></script>'
         s << '<noscript><a href="http://%s.disqus.com/?url=ref">'


### PR DESCRIPTION
First off, great gem. :P

I'm learning Rails and Ruby through Mozilla's Webcraft online course program, and used your gem to add comments to our blog sample project. I wanted to be able to refer to the same comment thread from multiple URLs (I have permalinks and you can also access posts via the post id). So I added the :identifier option to disqus_thread.

Let me know if I've made any big mistakes, still trying to learn the Right Way (tm) to do things in Ruby and Rails. :P Thanks!
