### PR TITLE
I've added helpers for supporing Disqus Single Sign-on

### DIFF
--- a/disqus.gemspec
+++ b/disqus.gemspec
@@ -10,7 +10,6 @@ spec = Gem::Specification.new do |s|
   s.summary           = "Integrates Disqus commenting system into your Ruby-powered site."
   s.description       = 'Integrates Disqus into your Ruby-powered site. Works with any Ruby website, and has view helpers for Rails and Merb.'
   s.homepage          = 'http://github.com/norman/disqus'
-  s.has_rdoc          = true
   s.platform          = Gem::Platform::RUBY
 
   s.files             = Dir["lib/**/*.rb", "lib/**/*.rake", "*.rdoc", "LICENSE", "Rakefile", "test/**/*.*"]

--- a/disqus.gemspec
+++ b/disqus.gemspec
@@ -1,3 +1,5 @@
+require 'lib/disqus/version'
+
 spec = Gem::Specification.new do |s|
 
   s.name              = "disqus"

--- a/lib/disqus.rb
+++ b/lib/disqus.rb
@@ -1,4 +1,4 @@
-%w[api author forum post thread version view_helpers widget].each do |file|
+%w[api author forum post thread view_helpers widget].each do |file|
   require File.join(File.dirname(__FILE__), "disqus", file)
 end
 

--- a/lib/disqus/view_helpers.rb
+++ b/lib/disqus/view_helpers.rb
@@ -1,6 +1,6 @@
 # Shortcuts to access the widgets as simple functions as opposed to using
 # their full qualified names.
-%w[combo comment_counts popular_threads recent_comments thread top_commenters].each do |method|
+%w[combo comment_counts popular_threads recent_comments thread top_commenters sso_login sso_logout].each do |method|
   eval(<<-EOM)
     def disqus_#{method}(options = {})
       Disqus::Widget.#{method}(options)

--- a/test/widget_test.rb
+++ b/test/widget_test.rb
@@ -28,6 +28,14 @@ class DisqusWidgetTest < Test::Unit::TestCase
     assert disqus_top_commenters
   end
 
+  def test_sso_login
+    assert disqus_sso_login(:public_key => 'app_public', :secret_key => 'app_secret', :user_id => 1, :username => 'Vasya Pupkin', :email => 'vasya@pupkin.ru')
+  end
+
+  def test_sso_logout
+    assert disqus_sso_logout(:public_key => 'app_public', :secret_key => 'app_secret')
+  end
+
   def test_invalid_default_tab
     assert_raises ArgumentError do
       disqus_combo(:default_tab => "test")


### PR DESCRIPTION
Hi!

I'm using disqus gem in my current project. I haven't found sso support in gem, that's why I've added them. You can merge mine changes with main branch if you think it's useful.

Thanks!
